### PR TITLE
Feature/fixup pylint example errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: PyLint
-      run: |
-        pylint $( find . -path './adafruit*.py' )
-        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,11 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: local
+    hooks:
+    -   id: pylint_examples
+        name: pylint-examples
+        entry: /usr/bin/env bash -c
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,bad-whitespace $example; done)']
+        language: system
+        description: Run example-specific pylint rules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,15 @@ repos:
     -   id: trailing-whitespace
 -   repo: local
     hooks:
+    -   id: "pylint-library"
+        name: "pylint-library"
+        entry: /usr/bin/env bash -c
+        args: ['pylint $( find . -path "./adafruit*.py" )']
+        language: system
+        description: Run pylint rules on library python code files
     -   id: pylint_examples
         name: pylint-examples
         entry: /usr/bin/env bash -c
         args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,bad-whitespace $example; done)']
         language: system
-        description: Run example-specific pylint rules
+        description: Run pylint rules on "examples/*.py" files


### PR DESCRIPTION
This add calls to `pylint` through the pre-commit hooks, instead of the GitHub workflow.

This is a draft PR until  the GitHub workflow actions in `build.yml` are also updated.