### PR TITLE
Optional position in resize

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -73,9 +73,10 @@ class GridLayout(displayio.Group):
                 button_size_y = cell["cell_size"][1]
 
                 new_position = (
-                    int(grid_position_x * self._width / grid_size_x) + self.cell_padding,
+                    int(grid_position_x * self._width / grid_size_x)
+                    + self.cell_padding,
                     int(grid_position_y * self._height / grid_size_y)
-                    + self.cell_padding
+                    + self.cell_padding,
                 )
 
                 print(
@@ -95,7 +96,7 @@ class GridLayout(displayio.Group):
                             int(button_size_y * self._height / grid_size_y)
                             - 2 * self.cell_padding
                         ),
-                        new_position
+                        new_position,
                     )
                 else:
                     # try width and height properties.
@@ -108,12 +109,8 @@ class GridLayout(displayio.Group):
                         - 2 * self.cell_padding
                     )
 
-                cell["content"].x = (
-                    new_position[0]
-                )
-                cell["content"].y = (
-                    new_position[1]
-                )
+                cell["content"].x = new_position[0]
+                cell["content"].y = new_position[1]
 
                 self.append(cell["content"])
 

--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -79,12 +79,6 @@ class GridLayout(displayio.Group):
                     + self.cell_padding,
                 )
 
-                print(
-                    "setting width to: {}".format(
-                        int(button_size_x * self._width / grid_size_x)
-                        - 2 * self.cell_padding
-                    )
-                )
                 if hasattr(cell["content"], "resize"):
                     # if it has resize function
                     cell["content"].resize(

--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -72,6 +72,12 @@ class GridLayout(displayio.Group):
                 button_size_x = cell["cell_size"][0]
                 button_size_y = cell["cell_size"][1]
 
+                new_position = (
+                    int(grid_position_x * self._width / grid_size_x) + self.cell_padding,
+                    int(grid_position_y * self._height / grid_size_y)
+                    + self.cell_padding
+                )
+
                 print(
                     "setting width to: {}".format(
                         int(button_size_x * self._width / grid_size_x)
@@ -89,6 +95,7 @@ class GridLayout(displayio.Group):
                             int(button_size_y * self._height / grid_size_y)
                             - 2 * self.cell_padding
                         ),
+                        new_position
                     )
                 else:
                     # try width and height properties.
@@ -102,11 +109,10 @@ class GridLayout(displayio.Group):
                     )
 
                 cell["content"].x = (
-                    int(grid_position_x * self._width / grid_size_x) + self.cell_padding
+                    new_position[0]
                 )
                 cell["content"].y = (
-                    int(grid_position_y * self._height / grid_size_y)
-                    + self.cell_padding
+                    new_position[1]
                 )
 
                 self.append(cell["content"])

--- a/adafruit_displayio_layout/widgets/switch_round.py
+++ b/adafruit_displayio_layout/widgets/switch_round.py
@@ -858,7 +858,7 @@ class SwitchRound(Widget, Control):
         self._radius = new_height // 2
         self._create_switch()
 
-    def resize(self, new_width, new_height):
+    def resize(self, new_width, new_height, position=None):
         """Resize the switch to a new requested width and height.
 
         :param int new_width: requested maximum width
@@ -866,6 +866,7 @@ class SwitchRound(Widget, Control):
         :return: None
 
         """
+        # pylint: disable=unused-argument
         # Fit the new button size within the requested maximum width/height
         # dimensions, but keeping an aspect ratio of 2:1 (width:height)
 

--- a/adafruit_displayio_layout/widgets/widget.py
+++ b/adafruit_displayio_layout/widgets/widget.py
@@ -217,6 +217,7 @@ class Widget(displayio.Group):
         :return: None
 
         """
+        # pylint: disable=unused-argument
         self._width = new_width
         self._height = new_height
 

--- a/adafruit_displayio_layout/widgets/widget.py
+++ b/adafruit_displayio_layout/widgets/widget.py
@@ -199,7 +199,7 @@ class Widget(displayio.Group):
 
         self._update_position()
 
-    def resize(self, new_width, new_height):
+    def resize(self, new_width, new_height, position=None):
         """Resizes the widget dimensions (for use with automated layout functions).
 
         **IMPORTANT:** The `resize` function should be overridden by the subclass definition.
@@ -211,6 +211,7 @@ class Widget(displayio.Group):
         the requested *new_width* and *new_height*. After resizing, the Widget's
         `bounding_box` should also be updated.
 
+        :param position: optional tuple with x,y position if subclasses want to use
         :param int new_width: target maximum width (in pixels)
         :param int new_height: target maximum height (in pixels)
         :return: None


### PR DESCRIPTION
This adds an optional argument for `position` to the resize function in Widget. 

subclasses can make use of this argument to do things that require knowing the position such as updating the touch_boundry to reflect the new size and location of a widget after it's been moved.

Using these changes and GridLayout I was able to make a grid of IconWidgets that are all individually touch capable.

![image](https://user-images.githubusercontent.com/2406189/110875397-26f40480-829b-11eb-8f90-81a2cb9eb809.png)
