### PR TITLE
icon_widget: Add animation

### DIFF
--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -21,24 +21,36 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
-
-
+import gc
+import time
 import terminalio
-from displayio import TileGrid
+import bitmaptools
+from displayio import TileGrid, Bitmap, Palette
 import adafruit_imageload
 from adafruit_display_text import bitmap_label
 from adafruit_displayio_layout.widgets.control import Control
 from adafruit_displayio_layout.widgets.widget import Widget
+from adafruit_displayio_layout.widgets.easing import quadratic_easeout as easein
+from adafruit_displayio_layout.widgets.easing import quadratic_easein as easeout
 
 
 class IconWidget(Widget, Control):
 
     """
     A touch enabled widget that holds an icon image loaded with
-    adafruit_imageload and a text label centered beneath it.
+    adafruit_imageload and a text label centered beneath it. Includes optional
+    animation to increase the icon size when pressed.
 
     :param string label_text: the text that will be shown beneath the icon image.
     :param string icon: the filepath of the bmp image to be used as the icon.
+
+    :param float max_scale: the maximum zoom during animation, set 1.0 for no animation
+     a value of 1.4 is a good starting point (default: 1.0, no animation),
+     ``max_scale`` must be >= 1.0
+    :param float max_angle: the maximum degrees of rotation during animation, set 0 for
+     no rotation, in degrees (default: 0 degrees)
+    :param float animation_time: the time for the animation in seconds, set to 0.0 for
+     no animation, a value of 0.15 is a good starting point (default: 0.15 seconds)
 
     :param int x: x location the icon widget should be placed. Pixel coordinates.
     :param int y: y location the icon widget should be placed. Pixel coordinates.
@@ -53,25 +65,62 @@ class IconWidget(Widget, Control):
 
     """
 
-    def __init__(self, label_text, icon, **kwargs):
-        super().__init__(**kwargs)
-        image, palette = adafruit_imageload.load(icon)
-        tile_grid = TileGrid(image, pixel_shader=palette)
+    # pylint: disable=bad-super-call, too-many-instance-attributes
+    # pylint: disable=too-many-arguments, unused-argument
+
+    def __init__(
+        self,
+        display,
+        label_text,
+        icon,
+        max_scale=1.0,
+        max_angle=8,
+        animation_time=0.0,
+        **kwargs
+    ):
+
+        super().__init__(**kwargs)  # initialize superclasses
+        super(Control, self).__init__()
+
+        self.display = display
+
+        self._image, self._palette = adafruit_imageload.load(icon)
+        tile_grid = TileGrid(self._image, pixel_shader=self._palette)
         self.append(tile_grid)
         _label = bitmap_label.Label(
             terminalio.FONT,
             scale=1,
             text=label_text,
             anchor_point=(0.5, 0),
-            anchored_position=(image.width // 2, image.height),
+            anchored_position=(self._image.width // 2, self._image.height),
         )
         self.append(_label)
         self.touch_boundary = (
             self.x,
             self.y,
-            image.width,
-            image.height + _label.bounding_box[3],
+            self._image.width,
+            self._image.height + _label.bounding_box[3],
         )
+
+        # verify the animation settings
+        self._start_scale = 1.0
+
+        max_scale = max(1.0, max_scale)  # constrain to > 1.0
+        if max_scale == 1.0:  # no animation
+            self._animation_time = 0
+        else:
+            self._animation_time = animation_time  # in seconds
+        self._end_scale = max_scale
+
+        self._angle = (max_angle / 360) * 2 * 3.14  # 5 degrees, convert to radians
+
+        # define zoom attributes
+        self._zoom_color_depth = None
+        self._zoom_palette = None
+        self._zoom_bitmap = None
+        self._zoom_tilegrid = None
+
+        self.value = False  # initial value
 
     def contains(self, touch_point):  # overrides, then calls Control.contains(x,y)
 
@@ -89,3 +138,111 @@ class IconWidget(Widget, Control):
         touch_y = touch_point[1] - self.y
 
         return super().contains((touch_x, touch_y, 0))
+
+    def selected(self, touch_point):
+        """Performs zoom animation when pressed.
+
+        :param touch_point: x,y location of the screen, converted to local coordinates.
+        :type touch_point: Tuple[x,y]
+        :return: None
+        """
+
+        self.value = True
+
+        if self._animation_time > 0:
+            ###
+            ## Create the zoom palette, bitmap and tilegrid
+            ###
+
+            # copy the image palette, add a transparent color at the end
+            self._zoom_color_depth = len(self._palette) + 1
+
+            self._zoom_palette = Palette(self._zoom_color_depth)
+            for i in range(len(self._palette)):
+                self._zoom_palette[i] = self._palette[i]
+            self._zoom_palette[self._zoom_color_depth - 1] = 0x000000
+            self._zoom_palette.make_transparent(self._zoom_color_depth - 1)
+
+            # create the zoom bitmap larger than the original image to allow for zooming
+            self._zoom_bitmap = Bitmap(
+                round(self._image.width * self._end_scale),
+                round(self._image.height * self._end_scale),
+                len(self._zoom_palette),
+            )
+            self._zoom_bitmap.fill(self._zoom_color_depth - 1)  # transparent fill
+            self._zoom_bitmap.blit(
+                (self._zoom_bitmap.width - self._image.width) // 2,
+                (self._zoom_bitmap.height - self._image.height) // 2,
+                self._image,
+            )  # blit the image into the center of the zoom_bitmap
+
+            # place zoom_bitmap at same location as image
+            self._zoom_tilegrid = TileGrid(
+                self._zoom_bitmap, pixel_shader=self._zoom_palette
+            )
+            self._zoom_tilegrid.x = -(self._zoom_bitmap.width - self._image.width) // 2
+            self._zoom_tilegrid.y = (
+                -(self._zoom_bitmap.height - self._image.height) // 2
+            )
+            self.append(self._zoom_tilegrid)  # add to the self group.
+
+            # Animation: zoom larger
+            start_time = time.monotonic()
+            while True:
+                elapsed_time = time.monotonic() - start_time
+                position = min(
+                    1.0, easein(elapsed_time / self._animation_time)
+                )  # fractional position
+                bitmaptools.rotozoom(
+                    dest_bitmap=self._zoom_bitmap,
+                    ox=self._zoom_bitmap.width // 2,
+                    oy=self._zoom_bitmap.height // 2,
+                    source_bitmap=self._image,
+                    px=self._image.width // 2,
+                    py=self._image.height // 2,
+                    scale=self._start_scale
+                    + position * (self._end_scale - self._start_scale),
+                    angle=position * self._angle / 2,
+                )
+                self.display.refresh()
+                if elapsed_time > self._animation_time:
+                    break
+
+    def released(self, touch_point):
+        """Performs un-zoom animation when released.
+
+        :param touch_point: x,y location of the screen, converted to local coordinates.
+        :type touch_point: Tuple[x,y]
+        :return: None
+        """
+
+        if (self._animation_time > 0) and self.value:
+            # Animation: shrink down to the original size
+            start_time = time.monotonic()
+            while True:
+                elapsed_time = time.monotonic() - start_time
+                position = max(0.0, easeout(1 - (elapsed_time / self._animation_time)))
+                self._zoom_bitmap.fill(self._zoom_color_depth - 1)
+                bitmaptools.rotozoom(
+                    dest_bitmap=self._zoom_bitmap,
+                    ox=self._zoom_bitmap.width // 2,
+                    oy=self._zoom_bitmap.height // 2,
+                    source_bitmap=self._image,
+                    px=self._image.width // 2,
+                    py=self._image.height // 2,
+                    scale=self._start_scale
+                    + position * (self._end_scale - self._start_scale),
+                    angle=position * self._angle / 2,
+                )
+                self.display.refresh()
+                if elapsed_time > self._animation_time:
+                    break
+
+            # clean up the zoom display elements
+            self.pop(-1)  # remove self from the group
+            del self._zoom_tilegrid
+            del self._zoom_bitmap
+            del self._zoom_palette
+            gc.collect()
+
+        self.value = False

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -64,16 +64,17 @@ class IconWidget(Widget, Control):
      displayio.Group constructor. If omitted we default to
      grid_size width * grid_size height to make room for all (1, 1) sized cells.
     :param int wheel_initial_value: When using palette animation, this is the initial value
-     of the colorwheel parameter used with ``_pixelbuf.colorwheel``
+     of the colorwheel parameter used with ``_pixelbuf.colorwheel`` (default: 0)
     :param int wheel_increment: To add palette animation, set this to the value of
      how much you want the ``_pixelbuf.colorwheel`` function to increment each time that
      ``unselected`` is called (default: 0 for no palette animation)
     :param int wheel_grading: This is the step sized used when calling colorwheel for
-     each color index in the palette (default: 5), basically it's how far apart each
+     each color index in the palette, basically it's how far apart each
      color in the palette will be set. Use a low value if you want each color to be
      close to each other or a high value to spread out into a wider range of colors.
+     (default: 5)
     :param int palette_skip_indices: integer or list of integers with the palette
-     indices that should not be changed when using the palette animations (default: None)
+     indices that will be kept constant using the palette animations (default: None)
 
     """
 

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -50,7 +50,7 @@ class IconWidget(Widget, Control):
     :param float max_angle: the maximum degrees of rotation during animation, set 0 for
      no rotation, in degrees (default: 0 degrees)
     :param float animation_time: the time for the animation in seconds, set to 0.0 for
-     no animation, a value of 0.15 is a good starting point (default: 0.15 seconds)
+     no animation, a value of 0.15 is a good starting point (default: 0.0 seconds)
 
     :param int x: x location the icon widget should be placed. Pixel coordinates.
     :param int y: y location the icon widget should be placed. Pixel coordinates.

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -100,11 +100,6 @@ class IconWidget(Widget, Control):
         max_scale=1.0,
         max_angle=8,
         animation_time=0.0,
-        wheel_initial_value=1,  # initial wheel color value
-        wheel_increment=0,  # how much the wheel
-        wheel_grading=5,  # sets the colorwheel distance between palette colors
-        palette_skip_indices=None,  # single value or list of palette color indices to
-        # remain constant during animations
         **kwargs,
     ):
 
@@ -162,16 +157,6 @@ class IconWidget(Widget, Control):
 
         self.value = False  # initial value
 
-        self._wheel_value = wheel_initial_value  # initial color wheel value
-        self._wheel_increment = (
-            wheel_increment  # color wheel increment for palette changing
-        )
-        self._wheel_grading = wheel_grading
-        if isinstance(palette_skip_indices, list):
-            self._palette_skip_indices = palette_skip_indices
-        else:
-            self._palette_skip_indices = [palette_skip_indices]
-
     def contains(self, touch_point):  # overrides, then calls Control.contains(x,y)
 
         """Checks if the IconWidget was touched.  Returns True if the touch_point is
@@ -189,7 +174,7 @@ class IconWidget(Widget, Control):
 
         return super().contains((touch_x, touch_y, 0))
 
-    def selected(self, touch_point):
+    def zoom_animation(self, touch_point):
         """Performs zoom animation when pressed.
 
         :param touch_point: x,y location of the screen, converted to local coordinates.
@@ -257,7 +242,7 @@ class IconWidget(Widget, Control):
             del _palette
             gc.collect()
 
-    def released(self, touch_point):
+    def zoom_out_animation(self, touch_point):
         """Performs un-zoom animation when released.
 
         :param touch_point: x,y location of the screen, converted to local coordinates.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ autodoc_mock_imports = [
     "adafruit_imageload",
     "adafruit_display_text",
     "bitmaptools",
+    "_pixelbuf",
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ autodoc_mock_imports = [
     "terminalio",
     "adafruit_imageload",
     "adafruit_display_text",
+    "bitmaptools",
 ]
 
 


### PR DESCRIPTION
This adds a zoom animation when the widget is `selected` and `released`.  

![icon_widget animation](https://user-images.githubusercontent.com/33587466/111096490-a12bbf80-850d-11eb-8ce5-561e5f8251b2.gif)

I added this feature to @FoamyGuy 's touch-deck code, with the example code here:
https://gist.github.com/kmatch98/aeae5c3b34754050037a294348416c52

To reduce memory usage, I used smaller icons with reduced colors compared to their original `touch_deck_icons` files.


![icon_animate_palette](https://user-images.githubusercontent.com/33587466/111373331-c2a1be00-8669-11eb-9376-b47cbb5b23dd.gif)


I updated this PR to include an option for `_pixelbuf.colorwheel` palette animation for `unselected` icons.  This adds several input parameters to control the palette animations, including an optional list of palette indices that are left untouched.


