### PR TITLE
fix setup_py to include the modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,9 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    packages=["adafruit_displayio_layout"],
+    packages=[
+        "adafruit_displayio_layout",
+        "adafruit_displayio_layout.layouts",
+        "adafruit_displayio_layout.widgets",
+    ],
 )


### PR DESCRIPTION
resolves #14

Added the modules into the list in `setup.py` so that they get properly installed via pip.

Tested by running 

```
pip install .
```
In the root of the repo.