### PR TITLE
update IconWidget touch_boundary to local coordinates

### DIFF
--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -75,8 +75,8 @@ class IconWidget(Widget, Control):
         )
         self.append(_label)
         self.touch_boundary = (
-            self.x,
-            self.y,
+            0,
+            0,
             image.width,
             image.height + _label.bounding_box[3],
         )


### PR DESCRIPTION
This corrects the issue observed in the comment: https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/pull/18#issuecomment-803690068

This sets the `touch_boundary` to use local coordinates, rather than global display coordinates.  The `IconWidget.contains()` function then corrects for global display positioning when calling the `Control.contains()` function with local coordinates.