### PR TITLE
Include examples in the API documentation

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -12,7 +12,7 @@ Pygame simple test
 
 Display Hello World using Blinka_Displayio_PyGameDisplay.
 
-.. literalinclude:: ..examples/displayio_layout_gridlayout_pygame_display_simpletest.py
+.. literalinclude:: ../examples/displayio_layout_gridlayout_pygame_display_simpletest.py
     :caption: examples/displayio_layout_gridlayout_pygame_display_simpletest.py
     :linenos:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,6 +7,15 @@ Ensure your device works with this simple test.
     :caption: examples/displayio_layout_simpletest.py
     :linenos:
 
+Pygame simple test
+----------------
+
+Display Hello World using Blinka_Displayio_PyGameDisplay.
+
+.. literalinclude:: ..examples/displayio_layout_gridlayout_pygame_display_simpletest.py
+    :caption: examples/displayio_layout_gridlayout_pygame_display_simpletest.py
+    :linenos:
+
 Switch simple test
 ------------------
 
@@ -23,4 +32,13 @@ Create multiple sliding switch with various sizes and orientations.
 
 .. literalinclude:: ../examples/displayio_layout_switch_multiple.py
     :caption: examples/displayio_layout_switch_multiple.py
+    :linenos:
+
+Dial simple test
+----------------
+
+Create a single dial.
+
+.. literalinclude:: ../examples/displayio_layout_dial_simpletest.py
+    :caption: examples/displayio_layout_dial_simpletest.py
     :linenos:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,7 +8,7 @@ Ensure your device works with this simple test.
     :linenos:
 
 Pygame simple test
-----------------
+------------------
 
 Display Hello World using Blinka_Displayio_PyGameDisplay.
 


### PR DESCRIPTION
To include some examples in the API documentation. They are missing in readthedocs