### PR TITLE
Move dependencies from autodoc mock imports to requirements.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,13 +29,7 @@ inheritance_graph_attrs = dict(rankdir="TB")
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = [
-    "displayio",
-    "adafruit_display_shapes",
     "vectorio",
-    "bitmaptools",
-    "terminalio",
-    "adafruit_imageload",
-    "adafruit_display_text",
     "bitmaptools",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 Adafruit-Blinka
+adafruit-blinka-displayio
+adafruit-circuitpython-display-shapes
+adafruit-circuitpython-imageload
+adafruit-circuitpython-display-text

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka",
+        "adafruit-blinka-displayio",
+        "adafruit-circuitpython-display-shapes",
+        "adafruit-circuitpython-imageload",
+        "adafruit-circuitpython-display-text",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
Since the JSON file looks in requirements, it's better to have them there.