### PR TITLE
Remove max_size parameter

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -40,17 +40,11 @@ class GridLayout(displayio.Group):
     :param int height: Height of the layout in pixels.
     :param tuple grid_size: Size in cells as two ints in a tuple e.g. (2, 2)
     :param int cell_padding: Extra padding space inside each cell. In pixels.
-    :param int max_size: (Optional) this will get passed through to the
-     displayio.Group constructor. If omitted we default to
-     grid_size width * grid_size height to make room for all (1, 1) sized cells.
-
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, x, y, width, height, grid_size, cell_padding, max_size=None):
-        if not max_size:
-            max_size = grid_size[0] * grid_size[1]
-        super().__init__(x=x, y=y, max_size=max_size)
+    def __init__(self, x, y, width, height, grid_size, cell_padding):
+        super().__init__(x=x, y=y)
         self.x = x
         self.y = y
         self._width = width

--- a/adafruit_displayio_layout/widgets/annotation.py
+++ b/adafruit_displayio_layout/widgets/annotation.py
@@ -181,7 +181,7 @@ class Annotation(Widget):
         self._line0 = Line(line_x0, line_y0, line_x1, line_y1, color=line_color)
         self._line1 = Line(line_x1, line_y1, line_x2, line_y2, color=line_color)
 
-        super().__init__(max_size=3)
+        super().__init__()
         # Group elements:
         # 0. Line0 - from (x,y) to (x+delta_x, y+delta_y)
         # 1. Line1 - horizontal line for text

--- a/adafruit_displayio_layout/widgets/cartesian.py
+++ b/adafruit_displayio_layout/widgets/cartesian.py
@@ -102,7 +102,7 @@ class Cartesian(Widget):
     .. code-block:: python
 
         my_plane= Plane(20, 30) # instance the plane at x=20, y=30
-        my_group = displayio.Group(max_size=10) # make a group that can hold 10 items
+        my_group = displayio.Group() # make a group
         my_group.append(my_plane) # Add my_plane to the group
 
         #
@@ -183,7 +183,7 @@ class Cartesian(Widget):
         **kwargs,
     ) -> None:
 
-        super().__init__(**kwargs, max_size=3)
+        super().__init__(**kwargs)
 
         self._background_color = background_color
 

--- a/adafruit_displayio_layout/widgets/dial.py
+++ b/adafruit_displayio_layout/widgets/dial.py
@@ -208,12 +208,8 @@ class Dial(Widget):
         value_label_anchor_on_widget=(0.5, 0.5),  # default label position on widget
         **kwargs,
     ):
-
         # initialize the Widget superclass (x, y, scale)
-        super().__init__(**kwargs, max_size=3)
-        # Define how many graphical elements will be in this group
-        # using "max_size=XX"
-        #
+        super().__init__(**kwargs)
         # Group elements for SwitchRoundHorizontal:
         #  0. TileGrid holding bitmap with ticks and tick label text
         #  1. Value label (optional)

--- a/adafruit_displayio_layout/widgets/flip_input.py
+++ b/adafruit_displayio_layout/widgets/flip_input.py
@@ -102,8 +102,7 @@ class FlipInput(Widget, Control):
         cool_down=0.0,
         **kwargs,
     ):
-
-        super().__init__(**kwargs, max_size=4)
+        super().__init__(**kwargs)
         # Group elements for the FlipInput.
         # 0. The text
         # 1. The group holding the temporary scroll bitmap
@@ -235,8 +234,7 @@ class FlipInput(Widget, Control):
         self._update_position()  # call Widget superclass function to reposition
 
         self._animation_group = displayio.Group(
-            max_size=1,
-            scale=self._font_scale,
+            scale=self._font_scale
         )  # holds the animation bitmap
         # self._animation_group.x = -1 * left * (1)
         # self._animation_group.y = -1 * top * (1)

--- a/adafruit_displayio_layout/widgets/icon_animated.py
+++ b/adafruit_displayio_layout/widgets/icon_animated.py
@@ -64,9 +64,6 @@ class IconAnimated(IconWidget):
     :type anchor_point: Tuple[float,float]
     :param int anchored_position: (x,y) pixel value for the location of the anchor_point
     :type anchored_position: Tuple[int, int]
-    :param int max_size: (Optional) this will get passed through to the
-     displayio.Group constructor. ``max_size`` should be set to the maximum number of
-     graphical elements that will be held within the Group of this widget.
     """
 
     # pylint: disable=bad-super-call, too-many-instance-attributes, too-many-locals
@@ -145,7 +142,7 @@ class IconAnimated(IconWidget):
         if self.__class__.display is None:
             raise ValueError(
                 "Must initialize class using\n"
-                "`IconAnimated.init_class(display, max_scale, max_size, max_color_depth)`\n"
+                "`IconAnimated.init_class(display, max_scale, max_color_depth)`\n"
                 "prior to instancing IconAnimated widgets."
             )
 

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -49,10 +49,6 @@ class IconWidget(Widget, Control):
     :type anchor_point: Tuple[float,float]
     :param int anchored_position: (x,y) pixel value for the location of the anchor_point
     :type anchored_position: Tuple[int, int]
-    :param int max_size: (Optional) this will get passed through to the
-     displayio.Group constructor. ``max_size`` should be set to the maximum number of
-     graphical elements that will be held within the Group of this widget.
-
     """
 
     def __init__(self, label_text, icon, on_disk=False, **kwargs):

--- a/adafruit_displayio_layout/widgets/switch_round.py
+++ b/adafruit_displayio_layout/widgets/switch_round.py
@@ -152,7 +152,7 @@ class SwitchRound(Widget, Control):
         .. code-block:: python
 
             my_switch = Switch(20, 30) # instance the switch at x=20, y=30
-            my_group = displayio.Group(max_size=10) # make a group that can hold 10 items
+            my_group = displayio.Group() # make a group
             my_group.append(my_switch) # Add my_switch to the group
 
             #
@@ -445,10 +445,7 @@ class SwitchRound(Widget, Control):
     ):
 
         # initialize the Widget superclass (x, y, scale)
-        super().__init__(x=x, y=y, height=height, width=width, **kwargs, max_size=4)
-        # Define how many graphical elements will be in this group
-        # using "max_size=XX"
-        #
+        super().__init__(x=x, y=y, height=height, width=width, **kwargs)
         # Group elements for SwitchRound:
         #  0. switch_roundrect: The switch background
         #  1. switch_circle: The switch button

--- a/adafruit_displayio_layout/widgets/widget.py
+++ b/adafruit_displayio_layout/widgets/widget.py
@@ -173,14 +173,10 @@ class Widget(displayio.Group):
         height=None,
         anchor_point=None,
         anchored_position=None,
-        **kwargs,
     ):
 
-        super().__init__(x=x, y=y, scale=scale, **kwargs)
+        super().__init__(x=x, y=y, scale=scale)
         # send x,y and scale to Group
-        # **kwargs should include `max_size`from the subclass implementation
-        # to define how many graphical elements will be held in the Group that
-        # makes up this widget
         #
         # If scale is set > 1, will need to update the Control `touch_boundary`
         # to accommodate the larger scale

--- a/examples/displayio_layout_annotation_simpletest.py
+++ b/examples/displayio_layout_annotation_simpletest.py
@@ -59,7 +59,7 @@ freeform_annotation = Annotation(
     text="Freeform annotation (display.width, height)",
 )
 
-my_group = displayio.Group(max_size=4)
+my_group = displayio.Group()
 my_group.append(my_switch)
 my_group.append(switch_annotation)
 my_group.append(switch_annotation_under)

--- a/examples/displayio_layout_cartesian_advanced_test.py
+++ b/examples/displayio_layout_cartesian_advanced_test.py
@@ -21,7 +21,7 @@ display = board.DISPLAY  # create the display on the PyPortal or Clue (for examp
 
 
 # Create different Cartesian widgets
-my_group = displayio.Group(max_size=10)
+my_group = displayio.Group()
 
 car = Cartesian(
     x=25,

--- a/examples/displayio_layout_cartesian_simpletest.py
+++ b/examples/displayio_layout_cartesian_simpletest.py
@@ -35,7 +35,7 @@ my_plane = Cartesian(
     font_color=0xFFFFFF,  # ticks line color
 )
 
-my_group = displayio.Group(max_size=3)
+my_group = displayio.Group()
 my_group.append(my_plane)
 display.show(my_group)  # add high level Group to the display
 

--- a/examples/displayio_layout_dial_simpletest.py
+++ b/examples/displayio_layout_dial_simpletest.py
@@ -39,7 +39,7 @@ my_dial = Dial(
     tick_label_scale=2.0,  # the scale factor for the tick label font
 )
 
-my_group = displayio.Group(max_size=1)
+my_group = displayio.Group()
 my_group.append(my_dial)
 
 display.show(my_group)  # add high level Group to the display

--- a/examples/displayio_layout_flip_input_simpletest.py
+++ b/examples/displayio_layout_flip_input_simpletest.py
@@ -92,7 +92,7 @@ my_flip2.value = my_flip2.value_list.index("21")  # find the index yourself by
 my_flip3.value = "2015"  # or set the value based on a string that is in the value_list
 
 # Create the group to display and append the FlipInput widgets
-my_group = displayio.Group(max_size=3)
+my_group = displayio.Group()
 my_group.append(my_flip1)
 my_group.append(my_flip2)
 my_group.append(my_flip3)

--- a/examples/displayio_layout_gridlayout_pygame_display_simpletest.py
+++ b/examples/displayio_layout_gridlayout_pygame_display_simpletest.py
@@ -15,7 +15,7 @@ from blinka_displayio_pygamedisplay import PyGameDisplay
 from adafruit_displayio_layout.layouts.grid_layout import GridLayout
 
 display = PyGameDisplay(width=320, height=240)
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 layout = GridLayout(

--- a/examples/displayio_layout_gridlayout_simpletest.py
+++ b/examples/displayio_layout_gridlayout_simpletest.py
@@ -17,7 +17,7 @@ from adafruit_displayio_layout.layouts.grid_layout import GridLayout
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 layout = GridLayout(
@@ -27,7 +27,6 @@ layout = GridLayout(
     height=100,
     grid_size=(2, 2),
     cell_padding=8,
-    max_size=10,
 )
 _labels = []
 

--- a/examples/displayio_layout_icon_animated_simpletest.py
+++ b/examples/displayio_layout_icon_animated_simpletest.py
@@ -48,7 +48,7 @@ icon_shrink = IconAnimated(
 
 icons = [icon_zoom, icon_shrink]
 
-main_group = displayio.Group(max_size=2)
+main_group = displayio.Group()
 main_group.append(icon_zoom)
 main_group.append(icon_shrink)
 

--- a/examples/displayio_layout_simpletest.py
+++ b/examples/displayio_layout_simpletest.py
@@ -19,7 +19,7 @@ from adafruit_displayio_layout.layouts.grid_layout import GridLayout
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 layout = GridLayout(
@@ -29,7 +29,6 @@ layout = GridLayout(
     height=100,
     grid_size=(2, 2),
     cell_padding=8,
-    max_size=10,
 )
 _labels = []
 

--- a/examples/displayio_layout_switch_multiple.py
+++ b/examples/displayio_layout_switch_multiple.py
@@ -91,7 +91,7 @@ my_switch8.anchored_position = (display.width - 10, display.height - 10)
 # the switch anchored_position is 10 pixels from the display
 # lower right corner
 
-my_group = displayio.Group(max_size=8)
+my_group = displayio.Group()
 my_group.append(my_switch)
 my_group.append(my_switch2)
 my_group.append(my_switch3)

--- a/examples/displayio_layout_switch_simpletest.py
+++ b/examples/displayio_layout_switch_simpletest.py
@@ -26,7 +26,7 @@ ts = adafruit_touchscreen.Touchscreen(
 my_switch = Switch(20, 30)
 
 
-my_group = displayio.Group(max_size=1)
+my_group = displayio.Group()
 my_group.append(my_switch)
 
 # Add my_group to the display


### PR DESCRIPTION
Remove usage of the `max_size` parameter now that it has been disabled in `shared-bindings`.

The examples have been tested on a Pynt:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```