### PR TITLE
fix OnDiskBitmap pixel_shader

### DIFF
--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -59,7 +59,7 @@ class IconWidget(Widget, Control):
         if on_disk:
             self._file = open(self._icon, "rb")
             image = OnDiskBitmap(self._file)
-            tile_grid = TileGrid(image, pixel_shader=ColorConverter())
+            tile_grid = TileGrid(image, pixel_shader=getattr(image, 'pixel_shader', ColorConverter()))
         else:
             image, palette = adafruit_imageload.load(icon)
             tile_grid = TileGrid(image, pixel_shader=palette)

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -60,7 +60,10 @@ class IconWidget(Widget, Control):
             self._file = open(self._icon, "rb")
             image = OnDiskBitmap(self._file)
             tile_grid = TileGrid(
-                image, pixel_shader=getattr(image, "pixel_shader", ColorConverter())
+                image,
+                pixel_shader=getattr(image, "pixel_shader", ColorConverter())
+                # TODO: Once CP6 is no longer supported replace the above line with below.
+                # tile_grid = TileGrid(image, pixel_shader=image.pixel_shader)
             )
         else:
             image, palette = adafruit_imageload.load(icon)

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -59,7 +59,9 @@ class IconWidget(Widget, Control):
         if on_disk:
             self._file = open(self._icon, "rb")
             image = OnDiskBitmap(self._file)
-            tile_grid = TileGrid(image, pixel_shader=getattr(image, 'pixel_shader', ColorConverter()))
+            tile_grid = TileGrid(
+                image, pixel_shader=getattr(image, "pixel_shader", ColorConverter())
+            )
         else:
             image, palette = adafruit_imageload.load(icon)
             tile_grid = TileGrid(image, pixel_shader=palette)


### PR DESCRIPTION
These changes are needed to support the new behavior of OnDiskBitmap from this PR: https://github.com/adafruit/circuitpython/pull/4823

Without these changes it causes IconAnimated and IconWidget to not be able to show the icons properly if they have on_disk=True parameter.