### PR TITLE
fix for content elements that dont allow setting width and height

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -79,15 +79,20 @@ class GridLayout(displayio.Group):
                         ),
                     )
                 else:
-                    # try width and height properties.
-                    cell["content"].width = (
-                        int(button_size_x * self._width / grid_size_x)
-                        - 2 * self.cell_padding
-                    )
-                    cell["content"].height = (
-                        int(button_size_y * self._height / grid_size_y)
-                        - 2 * self.cell_padding
-                    )
+                    try:
+                        # try width and height properties.
+                        cell["content"].width = (
+                            int(button_size_x * self._width / grid_size_x)
+                            - 2 * self.cell_padding
+                        )
+                        cell["content"].height = (
+                            int(button_size_y * self._height / grid_size_y)
+                            - 2 * self.cell_padding
+                        )
+                    except AttributeError:
+                        # This element does not allow setting width and height.
+                        # No problem, we'll use whatever size it already is.
+                        pass
 
                 cell["content"].x = (
                     int(grid_position_x * self._width / grid_size_x) + self.cell_padding


### PR DESCRIPTION
This fixes the issue noted here: https://github.com/adafruit/Adafruit_CircuitPython_MacroPad/issues/10

Label and BitmapLabel do not allow setting arbitrary width and height values. So we catch the exception and just use the size that the label already is. 

In the past Label and BitmapLabel had width and height class variables so those got set from GridLayout but did not actually change the visual appearance of the label. So catching this exception results in the exact behavior that we had previously.

