### PR TITLE
adding get_cell function to GridLayout

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -52,6 +52,7 @@ class GridLayout(displayio.Group):
         self.grid_size = grid_size
         self.cell_padding = cell_padding
         self._cell_content_list = []
+        self._cell_dictionary = {}
 
     def _layout_cells(self):
 
@@ -120,4 +121,24 @@ class GridLayout(displayio.Group):
             "cell_size": cell_size,
         }
         self._cell_content_list.append(sub_view_obj)
+        self._cell_dictionary[grid_position] = len(self._cell_content_list) - 1
         self._layout_cells()
+
+    def get_cell(self, cell_coordinates):
+        """
+        Return a cells content based on the cell_coordinates. Raises
+        KeyError if coordinates were not found in the GridLayout.
+
+        :param tuple cell_coordinates: the coordinates to lookup in the grid
+        :return: the displayio content object at those coordinates
+        """
+        if cell_coordinates in self._cell_dictionary:
+            return self._cell_content_list[self._cell_dictionary[cell_coordinates]][
+                "content"
+            ]
+
+        raise KeyError(
+            "GridLayout does not contain cell at coordinates {}".format(
+                cell_coordinates
+            )
+        )

--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -132,9 +132,7 @@ class GridLayout(displayio.Group):
         """
         for index, cell in enumerate(self._cell_content_list):
             if cell["grid_position"] == cell_coordinates:
-                return self._cell_content_list[index][
-                    "content"
-                ]
+                return self._cell_content_list[index]["content"]
 
         raise KeyError(
             "GridLayout does not contain cell at coordinates {}".format(

--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -52,7 +52,6 @@ class GridLayout(displayio.Group):
         self.grid_size = grid_size
         self.cell_padding = cell_padding
         self._cell_content_list = []
-        self._cell_dictionary = {}
 
     def _layout_cells(self):
 
@@ -121,7 +120,6 @@ class GridLayout(displayio.Group):
             "cell_size": cell_size,
         }
         self._cell_content_list.append(sub_view_obj)
-        self._cell_dictionary[grid_position] = len(self._cell_content_list) - 1
         self._layout_cells()
 
     def get_cell(self, cell_coordinates):
@@ -132,10 +130,11 @@ class GridLayout(displayio.Group):
         :param tuple cell_coordinates: the coordinates to lookup in the grid
         :return: the displayio content object at those coordinates
         """
-        if cell_coordinates in self._cell_dictionary:
-            return self._cell_content_list[self._cell_dictionary[cell_coordinates]][
-                "content"
-            ]
+        for index, cell in enumerate(self._cell_content_list):
+            if cell["grid_position"] == cell_coordinates:
+                return self._cell_content_list[index][
+                    "content"
+                ]
 
         raise KeyError(
             "GridLayout does not contain cell at coordinates {}".format(

--- a/examples/displayio_layout_grid_layout_get_cell_test.py
+++ b/examples/displayio_layout_grid_layout_get_cell_test.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2021 Tim C, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+Make green and purple rectangles and then update the color
+and text values of the labels using the get_cell() function.
+"""
+import board
+import displayio
+import terminalio
+from adafruit_display_text import label
+from adafruit_displayio_layout.layouts.grid_layout import GridLayout
+
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
+
+# Make the display context
+main_group = displayio.Group()
+display.show(main_group)
+
+layout = GridLayout(
+    x=10,
+    y=10,
+    width=200,
+    height=100,
+    grid_size=(2, 2),
+    cell_padding=8,
+)
+_labels = []
+
+_labels.append(
+    label.Label(
+        terminalio.FONT, scale=2, x=0, y=0, text="Hello", background_color=0x770077
+    )
+)
+layout.add_content(_labels[0], grid_position=(0, 0), cell_size=(1, 1))
+_labels.append(
+    label.Label(
+        terminalio.FONT, scale=2, x=0, y=0, text="World", background_color=0x007700
+    )
+)
+layout.add_content(_labels[1], grid_position=(1, 0), cell_size=(1, 1))
+_labels.append(label.Label(terminalio.FONT, scale=2, x=0, y=0, text="Hello"))
+layout.add_content(_labels[2], grid_position=(0, 1), cell_size=(1, 1))
+_labels.append(label.Label(terminalio.FONT, scale=2, x=0, y=0, text="Grid"))
+layout.add_content(_labels[3], grid_position=(1, 1), cell_size=(1, 1))
+
+main_group.append(layout)
+
+layout.get_cell((0, 0)).text = "Happy"
+layout.get_cell((1, 0)).text = "Circuit"
+
+layout.get_cell((0, 1)).text = "Python"
+layout.get_cell((1, 1)).text = "Day"
+
+layout.get_cell((0, 1)).background_color = 0x007700
+layout.get_cell((1, 1)).background_color = 0x770077
+
+while True:
+    pass


### PR DESCRIPTION
resolves #43 

Adding a new `get_cell()` function that allows you to lookup cell content objects by their coordinates within the GridLayout. Added a new example to illustrate this functionality.