### PR TITLE
Divider lines for GirdLayout

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -39,11 +39,27 @@ class GridLayout(displayio.Group):
     :param int height: Height of the layout in pixels.
     :param tuple grid_size: Size in cells as two ints in a tuple e.g. (2, 2)
     :param int cell_padding: Extra padding space inside each cell. In pixels.
-    :param bool divider_lines: Whether or not to draw lines between the cells.
+    :param bool divider_lines: Whether or not to draw lines between the cells. Defaults to False.
+    :param tuple h_divider_line_rows: Row indexes to draw divider lines above.
+        Row indexes are 0 based.
+    :param tuple v_divider_line_cols: Column indexes to draw divider lines before.
+        Column indexes are 0 based.
+
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, x, y, width, height, grid_size, cell_padding, divider_lines):
+    def __init__(
+        self,
+        x,
+        y,
+        width,
+        height,
+        grid_size,
+        cell_padding,
+        divider_lines=False,
+        h_divider_line_rows=None,
+        v_divider_line_cols=None,
+    ):
         super().__init__(x=x, y=y)
         self.x = x
         self.y = y
@@ -54,9 +70,11 @@ class GridLayout(displayio.Group):
         self._cell_content_list = []
         self._divider_lines_enabled = divider_lines
         self._divider_lines = []
+        self.h_divider_line_rows = h_divider_line_rows
+        self.v_divider_line_cols = v_divider_line_cols
 
     def _layout_cells(self):
-
+        # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         for cell in self._cell_content_list:
             if cell["content"] not in self:
                 grid_size_x = self.grid_size[0]
@@ -69,13 +87,13 @@ class GridLayout(displayio.Group):
                 button_size_y = cell["cell_size"][1]
 
                 _measured_width = (
-                        int(button_size_x * self._width / grid_size_x)
-                        - 2 * self.cell_padding
+                    int(button_size_x * self._width / grid_size_x)
+                    - 2 * self.cell_padding
                 )
 
                 _measured_height = (
-                        int(button_size_y * self._height / grid_size_y)
-                        - 2 * self.cell_padding
+                    int(button_size_y * self._height / grid_size_y)
+                    - 2 * self.cell_padding
                 )
                 if hasattr(cell["content"], "resize"):
                     # if it has resize function
@@ -99,20 +117,35 @@ class GridLayout(displayio.Group):
                 if not hasattr(cell["content"], "anchor_point"):
 
                     cell["content"].x = (
-                            int(grid_position_x * self._width / grid_size_x) + self.cell_padding
+                        int(grid_position_x * self._width / grid_size_x)
+                        + self.cell_padding
                     )
                     cell["content"].y = (
-                            int(grid_position_y * self._height / grid_size_y) + self.cell_padding
+                        int(grid_position_y * self._height / grid_size_y)
+                        + self.cell_padding
                     )
                 else:
-                    print("int({} * {} / {}) + {}".format(grid_position_x, self._width, grid_size_x, self.cell_padding))
                     print(
-                        "int({} * {} / {}) + {}".format(grid_position_y, self._height, grid_size_y, self.cell_padding))
+                        "int({} * {} / {}) + {}".format(
+                            grid_position_x, self._width, grid_size_x, self.cell_padding
+                        )
+                    )
+                    print(
+                        "int({} * {} / {}) + {}".format(
+                            grid_position_y,
+                            self._height,
+                            grid_size_y,
+                            self.cell_padding,
+                        )
+                    )
 
                     cell["content"].anchor_point = (0, 0)
                     cell["content"].anchored_position = (
-                        int(grid_position_x * self._width / grid_size_x) + self.cell_padding,
-                        int(grid_position_y * self._height / grid_size_y) + self.cell_padding)
+                        int(grid_position_x * self._width / grid_size_x)
+                        + self.cell_padding,
+                        int(grid_position_y * self._height / grid_size_y)
+                        + self.cell_padding,
+                    )
                     print(cell["content"].anchored_position)
                     print("---")
 
@@ -124,73 +157,131 @@ class GridLayout(displayio.Group):
                     palette[1] = 0xFFFFFF
 
                     if not hasattr(cell["content"], "anchor_point"):
-                        _bottom_line_loc_y = cell["content"].y + _measured_height + self.cell_padding
+                        _bottom_line_loc_y = (
+                            cell["content"].y + _measured_height + self.cell_padding
+                        )
                         _bottom_line_loc_x = cell["content"].x - self.cell_padding
 
                         _top_line_loc_y = cell["content"].y - self.cell_padding
                         _top_line_loc_x = cell["content"].x - self.cell_padding
 
                         _right_line_loc_y = cell["content"].y - self.cell_padding
-                        _right_line_loc_x = cell["content"].x + _measured_width + self.cell_padding
+                        _right_line_loc_x = (
+                            cell["content"].x + _measured_width + self.cell_padding
+                        )
                     else:
-                        _bottom_line_loc_y = cell["content"].anchored_position[1] + _measured_height + self.cell_padding
-                        _bottom_line_loc_x = cell["content"].anchored_position[0] - self.cell_padding
+                        _bottom_line_loc_y = (
+                            cell["content"].anchored_position[1]
+                            + _measured_height
+                            + self.cell_padding
+                        )
+                        _bottom_line_loc_x = (
+                            cell["content"].anchored_position[0] - self.cell_padding
+                        )
 
-                        _top_line_loc_y = cell["content"].anchored_position[1] - self.cell_padding
-                        _top_line_loc_x = cell["content"].anchored_position[0] - self.cell_padding
+                        _top_line_loc_y = (
+                            cell["content"].anchored_position[1] - self.cell_padding
+                        )
+                        _top_line_loc_x = (
+                            cell["content"].anchored_position[0] - self.cell_padding
+                        )
 
-                        _right_line_loc_y = cell["content"].anchored_position[1] - self.cell_padding
-                        _right_line_loc_x = cell["content"].anchored_position[0] + _measured_width + self.cell_padding
+                        _right_line_loc_y = (
+                            cell["content"].anchored_position[1] - self.cell_padding
+                        )
+                        _right_line_loc_x = (
+                            cell["content"].anchored_position[0]
+                            + _measured_width
+                            + self.cell_padding
+                        )
 
                     _horizontal_divider_line = displayio.Shape(
                         _measured_width + (2 * self.cell_padding),
                         1,
-                        mirror_x=False, mirror_y=False)
+                        mirror_x=False,
+                        mirror_y=False,
+                    )
 
                     _bottom_divider_tilegrid = displayio.TileGrid(
-                        _horizontal_divider_line, pixel_shader=palette,
+                        _horizontal_divider_line,
+                        pixel_shader=palette,
                         y=_bottom_line_loc_y,
-                        x=_bottom_line_loc_x)
+                        x=_bottom_line_loc_x,
+                    )
 
                     _top_divider_tilegrid = displayio.TileGrid(
-                        _horizontal_divider_line, pixel_shader=palette,
+                        _horizontal_divider_line,
+                        pixel_shader=palette,
                         y=_top_line_loc_y,
-                        x=_top_line_loc_x)
+                        x=_top_line_loc_x,
+                    )
 
                     _vertical_divider_line = displayio.Shape(
                         1,
                         _measured_height + (2 * self.cell_padding),
-                        mirror_x=False, mirror_y=False)
+                        mirror_x=False,
+                        mirror_y=False,
+                    )
 
                     _left_divider_tilegrid = displayio.TileGrid(
-                        _vertical_divider_line, pixel_shader=palette,
+                        _vertical_divider_line,
+                        pixel_shader=palette,
                         y=_top_line_loc_y,
-                        x=_top_line_loc_x)
+                        x=_top_line_loc_x,
+                    )
 
                     _right_divider_tilegrid = displayio.TileGrid(
-                        _vertical_divider_line, pixel_shader=palette,
+                        _vertical_divider_line,
+                        pixel_shader=palette,
                         y=_right_line_loc_y,
-                        x=_right_line_loc_x)
+                        x=_right_line_loc_x,
+                    )
 
                     for line_obj in self._divider_lines:
                         self.remove(line_obj["tilegrid"])
 
-                    self._divider_lines.append({
-                        "shape": _horizontal_divider_line,
-                        "tilegrid": _bottom_divider_tilegrid
-                    })
-                    self._divider_lines.append({
-                        "shape": _horizontal_divider_line,
-                        "tilegrid": _top_divider_tilegrid
-                    })
-                    self._divider_lines.append({
-                        "shape": _horizontal_divider_line,
-                        "tilegrid": _left_divider_tilegrid
-                    })
-                    self._divider_lines.append({
-                        "shape": _vertical_divider_line,
-                        "tilegrid": _right_divider_tilegrid
-                    })
+                    print("pos_y: {} - size_y: {}".format(grid_position_y, grid_size_y))
+                    print(grid_position_y == grid_size_y)
+                    if grid_position_y == grid_size_y - 1 and (
+                        self.h_divider_line_rows is None
+                        or grid_position_y + 1 in self.h_divider_line_rows
+                    ):
+                        self._divider_lines.append(
+                            {
+                                "shape": _horizontal_divider_line,
+                                "tilegrid": _bottom_divider_tilegrid,
+                            }
+                        )
+                    if (
+                        self.h_divider_line_rows is None
+                        or grid_position_y in self.h_divider_line_rows
+                    ):
+                        self._divider_lines.append(
+                            {
+                                "shape": _horizontal_divider_line,
+                                "tilegrid": _top_divider_tilegrid,
+                            }
+                        )
+                    if (
+                        self.v_divider_line_cols is None
+                        or grid_position_x in self.v_divider_line_cols
+                    ):
+                        self._divider_lines.append(
+                            {
+                                "shape": _horizontal_divider_line,
+                                "tilegrid": _left_divider_tilegrid,
+                            }
+                        )
+                    if grid_position_x == grid_size_x - 1 and (
+                        self.v_divider_line_cols is None
+                        or grid_position_x + 1 in self.v_divider_line_cols
+                    ):
+                        self._divider_lines.append(
+                            {
+                                "shape": _vertical_divider_line,
+                                "tilegrid": _right_divider_tilegrid,
+                            }
+                        )
 
                     for line_obj in self._divider_lines:
                         self.append(line_obj["tilegrid"])

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,6 +7,15 @@ Ensure your device works with this simple test.
     :caption: examples/displayio_layout_simpletest.py
     :linenos:
 
+GridLayout divider lines example
+--------------------------------
+
+Create GridLayouts with divider lines.
+
+.. literalinclude:: ../examples/displayio_layout_gridlayout_dividers.py
+    :caption: examples/displayio_layout_gridlayout_dividers.py
+    :linenos:
+
 Pygame simple test
 ------------------
 

--- a/examples/displayio_layout_gridlayout_dividers.py
+++ b/examples/displayio_layout_gridlayout_dividers.py
@@ -56,9 +56,7 @@ other_layout = GridLayout(
     height=80,
     grid_size=(2, 3),
     cell_padding=4,
-    divider_lines=True,
     h_divider_line_rows=(1, 2),  # Lines before rows 1 and 2
-    v_divider_line_cols=(),  # No vertical divider lines
 )
 
 other_layout.add_content(

--- a/examples/displayio_layout_gridlayout_dividers.py
+++ b/examples/displayio_layout_gridlayout_dividers.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2021 Tim C, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+Illustrate how to use divider lines with GridLayout
+"""
+import board
+import displayio
+import terminalio
+from adafruit_display_text import label
+from adafruit_displayio_layout.layouts.grid_layout import GridLayout
+
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
+
+# Make the display context
+main_group = displayio.Group()
+display.show(main_group)
+
+layout = GridLayout(
+    x=10,
+    y=10,
+    width=200,
+    height=100,
+    grid_size=(2, 2),
+    cell_padding=8,
+    divider_lines=True,  # divider lines around every cell
+)
+_labels = []
+
+_labels.append(
+    label.Label(
+        terminalio.FONT, scale=2, x=0, y=0, text="Hello", background_color=0x770077
+    )
+)
+layout.add_content(_labels[0], grid_position=(0, 0), cell_size=(1, 1))
+_labels.append(
+    label.Label(
+        terminalio.FONT, scale=2, x=0, y=0, text="World", background_color=0x007700
+    )
+)
+layout.add_content(_labels[1], grid_position=(1, 0), cell_size=(1, 1))
+_labels.append(label.Label(terminalio.FONT, scale=2, x=0, y=0, text="Hello"))
+layout.add_content(_labels[2], grid_position=(0, 1), cell_size=(1, 1))
+_labels.append(label.Label(terminalio.FONT, scale=2, x=0, y=0, text="Grid"))
+layout.add_content(_labels[3], grid_position=(1, 1), cell_size=(1, 1))
+
+main_group.append(layout)
+
+other_layout = GridLayout(
+    x=10,
+    y=120,
+    width=140,
+    height=80,
+    grid_size=(2, 3),
+    cell_padding=4,
+    divider_lines=True,
+    h_divider_line_rows=(1, 2),  # Lines before rows 1 and 2
+    v_divider_line_cols=(),  # No vertical divider lines
+)
+
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="0x0"), grid_position=(0, 0), cell_size=(1, 1)
+)
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="0x1"), grid_position=(0, 1), cell_size=(1, 1)
+)
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="0x2"), grid_position=(0, 2), cell_size=(1, 1)
+)
+
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="1x0"), grid_position=(1, 0), cell_size=(1, 1)
+)
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="1x1"), grid_position=(1, 1), cell_size=(1, 1)
+)
+other_layout.add_content(
+    label.Label(terminalio.FONT, text="1x2"), grid_position=(1, 2), cell_size=(1, 1)
+)
+
+main_group.append(other_layout)
+
+while True:
+    pass


### PR DESCRIPTION
Resolves: #44 

This update includes configuration options for GridLayout to allow divider lines to be drawn within the grid. It supports a simple True / False to enable or disable the lines and optional extra configurations to specify lines only on certain rows or columns.

There is a new example to illustrate this functionality. Here is how it looks when run on a PyPortal:
![image](https://user-images.githubusercontent.com/2406189/131265125-b0b69436-233f-472a-82ec-43b524bf105c.png)

The top grid simply turns divider lines on and uses the default configuration to draw them around every cell.

The lower grid uses the extra configurations to draw divider lines before rows with indexes 1 and 2 and draws no vertical divider lines.