### PR TITLE
Handle missing bitmaptools

### DIFF
--- a/adafruit_displayio_layout/widgets/__init__.py
+++ b/adafruit_displayio_layout/widgets/__init__.py
@@ -11,7 +11,7 @@ import vectorio
 
 try:
     import bitmaptools
-except NameError:
+except ImportError:
     pass
 
 

--- a/adafruit_displayio_layout/widgets/cartesian.py
+++ b/adafruit_displayio_layout/widgets/cartesian.py
@@ -33,9 +33,6 @@ from adafruit_displayio_layout.widgets import rectangle_helper
 
 try:
     import bitmaptools
-except NameError:
-    pass
-try:
     from typing import Tuple
 except ImportError:
     pass

--- a/adafruit_displayio_layout/widgets/cartesian.py
+++ b/adafruit_displayio_layout/widgets/cartesian.py
@@ -33,6 +33,10 @@ from adafruit_displayio_layout.widgets import rectangle_helper
 
 try:
     import bitmaptools
+except ImportError:
+    pass
+
+try:
     from typing import Tuple
 except ImportError:
     pass


### PR DESCRIPTION
If bitmaptools is missing an ImportError will be raised.
This handles the correct Error.