### PR TITLE
Missing int conversions on cell_anchor_point math

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -176,10 +176,10 @@ class GridLayout(displayio.Group):
                     cell["content"].anchored_position = (
                         int(grid_position_x * self._width / grid_size_x)
                         + self.cell_padding
-                        + (cell["cell_anchor_point"][0] * _measured_width),
+                        + int(cell["cell_anchor_point"][0] * _measured_width),
                         int(grid_position_y * self._height / grid_size_y)
                         + self.cell_padding
-                        + (cell["cell_anchor_point"][1] * _measured_height),
+                        + int(cell["cell_anchor_point"][1] * _measured_height),
                     )
 
                 self.append(cell["content"])
@@ -236,29 +236,29 @@ class GridLayout(displayio.Group):
                             cell["content"].anchored_position[1]
                             + _measured_height
                             + self.cell_padding
-                            - (cell["cell_anchor_point"][1] * _measured_height)
+                            - int(cell["cell_anchor_point"][1] * _measured_height)
                         ) - 1
                         _bottom_line_loc_x = (
                             cell["content"].anchored_position[0]
                             - self.cell_padding
-                            - (cell["cell_anchor_point"][0] * _measured_width)
+                            - int(cell["cell_anchor_point"][0] * _measured_width)
                         )
 
                         _top_line_loc_y = (
                             cell["content"].anchored_position[1]
                             - self.cell_padding
-                            - (cell["cell_anchor_point"][1] * _measured_height)
+                            - int(cell["cell_anchor_point"][1] * _measured_height)
                         )
                         _top_line_loc_x = (
                             cell["content"].anchored_position[0]
                             - self.cell_padding
-                            - (cell["cell_anchor_point"][0] * _measured_width)
+                            - int(cell["cell_anchor_point"][0] * _measured_width)
                         )
 
                         _right_line_loc_y = (
                             cell["content"].anchored_position[1]
                             - self.cell_padding
-                            - (cell["cell_anchor_point"][1] * _measured_height)
+                            - int(cell["cell_anchor_point"][1] * _measured_height)
                         )
                         _right_line_loc_x = (
                             (
@@ -267,7 +267,7 @@ class GridLayout(displayio.Group):
                                 + self.cell_padding
                             )
                             - 1
-                            - (cell["cell_anchor_point"][0] * _measured_width)
+                            - int(cell["cell_anchor_point"][0] * _measured_width)
                         )
 
                     _horizontal_divider_line = displayio.Shape(


### PR DESCRIPTION
In multiple places where `cell["cell_anchor_point"] * X` is used, the int conversion is missing, causing an error when an anchor_point is set to `(0.5, 0.5)` for example. I only encountered the issue with lines 179-182, but I think the others are required too.
```
Traceback (most recent call last):
  File "code.py", line 9, in <module>
  File "code_pyportal.py", line 285, in switch_page
  File "/lib/adafruit_displayio_layout/layouts/grid_layout.py", line 413, in add_content
  File "/lib/adafruit_displayio_layout/layouts/grid_layout.py", line 182, in _layout_cells
  File "/lib/adafruit_displayio_layout/widgets/widget.py", line 297, in anchored_position
  File "/lib/adafruit_displayio_layout/widgets/widget.py", line 234, in _update_position
TypeError: can't convert float to int
```
I didn't look into the math but I wonder, should it use `round()` rather that `int()` ? (which always rounds down)