### PR TITLE
transparency in icon image. Background color for label.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ adafruit-blinka-displayio
 adafruit-circuitpython-display-shapes
 adafruit-circuitpython-imageload
 adafruit-circuitpython-display-text
+adafruit-circuitpython-bitmap-font


### PR DESCRIPTION
This adds two new features to the IconWidget both exposed as arguments to the constructor

- `label_background` which can be set to a hex color i.e. `0x888888` and will get set as the color in the  background of the icon label.
- `transparency_index` which can be set to an integer index within the palette of the icon bmp image. If set this will call `make_transparent()` on the given index to make it not get drawn on the display.

Both of these new features are used in the PyPortal Busy Simulator app that I am working on a guide for.