### PR TITLE
Reintroduce graphviz

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,5 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Load graphviz
+      run: |
+        sudo apt install graphviz
     - name: Run Build CI workflow
       uses: adafruit/workflows-circuitpython-libs/build@main


### PR DESCRIPTION
Needed to build `sphinx` documentation, and was in the original CI files for this library.