### PR TITLE
Add graphviz as package on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3"
+  apt_packages:
+    - graphviz
 
 python:
   install:


### PR DESCRIPTION
Fixes #81 using the solution provided in https://github.com/readthedocs/readthedocs.org/issues/8800, which explains I wasn't able to replicate what's happening on RTD, since I have `graphviz` locally and sphinx builds it fine for me there.