### PR TITLE
Removing Vectorshape Usage

### DIFF
--- a/adafruit_displayio_layout/widgets/__init__.py
+++ b/adafruit_displayio_layout/widgets/__init__.py
@@ -58,10 +58,10 @@ def rectangle_helper(
     if bitmaptool:
         bitmaptools.fill_region(bitmap, x0, y0, x0 + width, y0 + height, color_index)
     else:
-        rect = vectorio.Rectangle(width, height)
-        vectorio.VectorShape(
-            shape=rect,
+        vectorio.Rectangle(
             pixel_shader=palette,
+            width=width,
+            height=height,
             x=x0,
             y=y0,
         )


### PR DESCRIPTION
After CircuitPython 7.0.0 the usage of vectorshape has been deprecated. The current library has a rectangle_helper that uses it. 
https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/blob/29fe3f0bdda917c6c8efbdcba94885eeb6963fa3/adafruit_displayio_layout/widgets/__init__.py#L62
However after CP 7.0 this function becomes obsolete as the API for vectorio needs to add the shape to the group using the corresponding palette. Open for discussion, that having only the fill_area from bitmaptools will be easier than refactoring the cartesian to draw with both libraries. See documentation for vectorio.recatngle. So maybe there is a workaround but I could not find it during my tests. 

```py
group = displayio.Group()

palette = displayio.Palette(1)
palette[0] = 0x125690

rectangle = vectorio.Rectangle(pixel_shader=palette, width=40, height=30, x=55, y=45)
group.append(rectangle)
```

Cartesian is the only library using this, and is already hardcoded to use bitmaptool library only. 
https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/blob/29fe3f0bdda917c6c8efbdcba94885eeb6963fa3/adafruit_displayio_layout/widgets/cartesian.py#L360
