### PR TITLE
changes for blit refactor to bitmaptools.

### DIFF
--- a/adafruit_displayio_layout/widgets/flip_input.py
+++ b/adafruit_displayio_layout/widgets/flip_input.py
@@ -25,7 +25,7 @@ import gc
 import time
 import displayio
 from terminalio import FONT
-
+import bitmaptools
 from adafruit_display_shapes.triangle import Triangle
 
 from adafruit_display_text import bitmap_label
@@ -42,7 +42,6 @@ try:
     from typing import Any, List, Optional, Tuple
 except ImportError:
     pass
-
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
@@ -381,7 +380,12 @@ class FlipInput(Widget, Control):
             start_bitmap = displayio.Bitmap(
                 self._label.bitmap.width, self._label.bitmap.height, 2
             )  # color depth 2
-            start_bitmap.blit(0, 0, self._label.bitmap)
+
+            # CircuitPython Versions <= 8.2.0
+            # start_bitmap.blit(0, 0, self._label.bitmap)
+
+            # CircuitPython Versions >= 9.0.0
+            bitmaptools.blit(start_bitmap, self._label.bitmap, 0, 0)
 
             # get the bitmap1 position offsets
             bitmap1_offset = (
@@ -555,11 +559,20 @@ def _draw_position(
 
     if position == 0.0:
         target_bitmap.fill(0)
-        target_bitmap.blit(x_offset1, y_offset1, bitmap1)
+
+        # CircuitPython Versions <= 8.2.0
+        # target_bitmap.blit(x_offset1, y_offset1, bitmap1)
+
+        # CircuitPython Versions >= 9.0.0
+        bitmaptools.blit(target_bitmap, bitmap1, x_offset1, y_offset1)
         return
     if position == 1.0:
         target_bitmap.fill(0)
-        target_bitmap.blit(x_offset2, y_offset2, bitmap2)
+        # CircuitPython Versions <= 8.2.0
+        # target_bitmap.blit(x_offset2, y_offset2, bitmap2)
+
+        # CircuitPython Versions >= 9.0.0
+        bitmaptools.blit(target_bitmap, bitmap2, x_offset2, y_offset2)
         return
 
     if horizontal:
@@ -641,7 +654,11 @@ def _blit_constrained(
     ):
         return
 
-    target.blit(x, y, source, x1=x1, y1=y1, x2=x2, y2=y2)
+    # CircuitPython Versions <= 8.2.0
+    # target.blit(x, y, source, x1=x1, y1=y1, x2=x2, y2=y2)
+
+    # CircuitPython Versions >= 9.0.0
+    bitmaptools.blit(target, source, x, y, x1=x1, y1=y1, x2=x2, y2=y2)
 
 
 # _animate_bitmap - performs animation of scrolling between two bitmaps

--- a/adafruit_displayio_layout/widgets/icon_animated.py
+++ b/adafruit_displayio_layout/widgets/icon_animated.py
@@ -37,13 +37,11 @@ try:
 except ImportError:
     pass
 
-
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
 
 
 class IconAnimated(IconWidget):
-
     """
     An animated touch enabled widget that holds an icon image loaded with
     OnDiskBitmap and a text label centered beneath it. Includes optional
@@ -80,6 +78,7 @@ class IconAnimated(IconWidget):
     # pylint: disable=too-many-arguments, unused-argument
 
     display = None
+
     # The other Class variables are created in Class method `init_class`:
     #               max_scale, bitmap_buffer, palette_buffer
 
@@ -226,11 +225,22 @@ class IconAnimated(IconWidget):
 
             # create the zoom bitmap larger than the original image to allow for zooming
             animation_bitmap.fill(len(animation_palette) - 1)  # transparent fill
-            animation_bitmap.blit(
-                (animation_bitmap.width - _image.width) // 2,
-                (animation_bitmap.height - _image.height) // 2,
-                _image,
-            )  # blit the image into the center of the zoom_bitmap
+
+            if hasattr(animation_bitmap, "blit"):
+                # CircuitPython Versions <= 8.2.0
+                animation_bitmap.blit(
+                    (animation_bitmap.width - _image.width) // 2,
+                    (animation_bitmap.height - _image.height) // 2,
+                    _image,
+                )  # blit the image into the center of the zoom_bitmap
+            elif hasattr(bitmaptools, "blit"):
+                # CircuitPython Versions >= 9.0.0
+                bitmaptools.blit(
+                    animation_bitmap,
+                    _image,
+                    (animation_bitmap.width - _image.width) // 2,
+                    (animation_bitmap.height - _image.height) // 2,
+                )
 
             # place zoom_bitmap at same location as image
             animation_tilegrid = TileGrid(


### PR DESCRIPTION
These changes go along with [#8136](https://github.com/adafruit/circuitpython/pull/8136) in the core.

I made icon_animated fully backward and forwards compatible with hasattr logic. For flip_input, there were several locations which needed updating so I opted for something more concise in leaving a comment with the prior version and adding the new version below. 

I'm open to other options as well. If there is a desire to forego backwards compatibility altogether, or a preference to make flip_input use the logic to be compatible without switching commented lines.