### PR TITLE
Remove '__version__' and '__repo__' to save RAM

### DIFF
--- a/adafruit_displayio_layout/layouts/grid_layout.py
+++ b/adafruit_displayio_layout/layouts/grid_layout.py
@@ -32,9 +32,6 @@ import math
 import displayio
 from vectorio import Rectangle
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
 
 class GridLayout(displayio.Group):
     """

--- a/adafruit_displayio_layout/layouts/page_layout.py
+++ b/adafruit_displayio_layout/layouts/page_layout.py
@@ -32,9 +32,6 @@ except ImportError:
 
 import displayio
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
 
 class PageLayout(displayio.Group):
     """

--- a/adafruit_displayio_layout/layouts/tab_layout.py
+++ b/adafruit_displayio_layout/layouts/tab_layout.py
@@ -37,9 +37,6 @@ from adafruit_display_text.bitmap_label import Label
 from adafruit_imageload.tilegrid_inflator import inflate_tilegrid
 from adafruit_displayio_layout.layouts.page_layout import PageLayout
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
 
 class TabLayout(displayio.Group):
     """

--- a/adafruit_displayio_layout/widgets/cartesian.py
+++ b/adafruit_displayio_layout/widgets/cartesian.py
@@ -41,10 +41,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 class Cartesian(Widget):
     """A cartesian widget.  The origin is set using ``x`` and ``y``.
 

--- a/adafruit_displayio_layout/widgets/control.py
+++ b/adafruit_displayio_layout/widgets/control.py
@@ -27,9 +27,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
 # pylint: disable=unsubscriptable-object, unnecessary-pass
 
 

--- a/adafruit_displayio_layout/widgets/easing.py
+++ b/adafruit_displayio_layout/widgets/easing.py
@@ -76,10 +76,6 @@ Implementation Notes
 import math
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 # Modeled after the line y = x
 def linear_interpolation(pos: float) -> float:
     """

--- a/adafruit_displayio_layout/widgets/flip_input.py
+++ b/adafruit_displayio_layout/widgets/flip_input.py
@@ -44,10 +44,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 # pylint: disable=too-many-arguments, too-many-branches, too-many-statements
 # pylint: disable=too-many-locals, too-many-instance-attributes
 

--- a/adafruit_displayio_layout/widgets/icon_animated.py
+++ b/adafruit_displayio_layout/widgets/icon_animated.py
@@ -38,10 +38,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 class IconAnimated(IconWidget):
 
     """

--- a/adafruit_displayio_layout/widgets/icon_widget.py
+++ b/adafruit_displayio_layout/widgets/icon_widget.py
@@ -36,10 +36,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 class IconWidget(Widget, Control):
 
     """

--- a/adafruit_displayio_layout/widgets/switch_round.py
+++ b/adafruit_displayio_layout/widgets/switch_round.py
@@ -50,10 +50,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
-
 class SwitchRound(Widget, Control):
 
     """

--- a/adafruit_displayio_layout/widgets/widget.py
+++ b/adafruit_displayio_layout/widgets/widget.py
@@ -30,9 +30,6 @@ except ImportError:
     pass
 
 
-__version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout.git"
-
 # pylint: disable=too-many-arguments
 
 


### PR DESCRIPTION
As said in the title, this removes the `__version__` and `__repo__` symbols from all modules to save up on RAM.

During my testing on an Feather RP2040 CAN, I was able to save 2.5 kB of that precious RAM in a worst-case scenario (= all modules being imported). This represents almost 1% of that MCU's total amount.

Notes: to get the numbers below, I applied the same optimization to [Adafruit_CircuitPython_imageload](https://github.com/adafruit/Adafruit_CircuitPython_imageload), on which this module depends, and all the libraries were compiled to `.mpy` beforehand using `mpy-cross` v9.2.1, which is the exact CP version that my board is running.

Code used to test:
```python
import gc

from adafruit_displayio_layout import *
from adafruit_displayio_layout.layouts.grid_layout import *
from adafruit_displayio_layout.layouts.linear_layout import *
from adafruit_displayio_layout.layouts.page_layout import *
from adafruit_displayio_layout.layouts.tab_layout import *
from adafruit_displayio_layout.widgets.cartesian import *
from adafruit_displayio_layout.widgets.control import *
from adafruit_displayio_layout.widgets.easing import *
from adafruit_displayio_layout.widgets.flip_input import *
from adafruit_displayio_layout.widgets.icon_animated import *
from adafruit_displayio_layout.widgets.icon_widget import *
from adafruit_displayio_layout.widgets.switch_round import *
from adafruit_displayio_layout.widgets.widget import *

print(gc.mem_alloc())
```

results:
* before: 59792 bytes
* after:  57216 bytes
* saved: 2576 bytes