### PR TITLE
 Update how board.DISPLAY is checked

### DIFF
--- a/adafruit_displayio_layout/layouts/tab_layout.py
+++ b/adafruit_displayio_layout/layouts/tab_layout.py
@@ -87,10 +87,8 @@ class TabLayout(displayio.Group):
     ):
         if display is None:
             # pylint: disable=import-outside-toplevel
-            import board
-
-            if hasattr(board, "DISPLAY"):
-                display = board.DISPLAY
+            import board  
+            display = getattr(board, "DISPLAY", None)
         if inactive_tab_spritesheet is None:
             raise AttributeError("Must pass inactive_tab_spritesheet")
         if showing_tab_spritesheet is None:


### PR DESCRIPTION
Historically, boards with no built-in display have not had a `board.DISPLAY` property.

Soon, with https://github.com/adafruit/circuitpython/pull/10028, any board with displayio will have a `board.DISPLAY` property. This property will be `None` if no display is configured, or a truthy non-`None` value if a display is configured (including dynamically at runtime).

This revised check will work on both old and new circuitpython versions.