### PR TITLE
Update .readthedocs.yml build OS to ubuntu-lts-latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3"
   apt_packages:


### PR DESCRIPTION
20.04 is deprecated by RTD; ubuntu-lts-latest is used by most of our libraries.